### PR TITLE
change to constructor

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -31,6 +31,7 @@ _(loosely in this order...)_
 - [x] add Grunfile
 - [ ] coverage reports
 - [ ] API documentation, written as code comments
+- [ ] Add links to website docs for any methods that have more info
 - [ ] Add the event to the changelogs of both libraries
 
 **Next:**

--- a/.verb.md
+++ b/.verb.md
@@ -1,4 +1,4 @@
-# {%= name %} {%= badge("fury") %}
+# {%= name %} {%= badge("fury") %} {%= badge("built-with-grunt") %}
 
 > {%= description %}
 
@@ -37,6 +37,8 @@ _(loosely in this order...)_
 
 - [ ] replace core `grunt.{%= replace(name, "grunt-legacy-", "") %}` internal module with `{%= name %} `
 - [ ] remove any dependencies that are no longer needed from grunt.
+- [ ] enable travis
+- [ ] add travis badge
 
 ## Related projects
 {%= related(['grunt', 'grunt-cli', 'grunt-legacy-log', 'grunt-legacy-util']) %}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,0 @@
-v0.1.0:
-  date: 2015-05-04
-  changes:
-    - First commit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-legacy-file [![NPM version](https://badge.fury.io/js/grunt-legacy-file.svg)](http://badge.fury.io/js/grunt-legacy-file)
+# grunt-legacy-file [![NPM version](https://badge.fury.io/js/grunt-legacy-file.svg)](http://badge.fury.io/js/grunt-legacy-file) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
 
 > Grunt's file methods.
 
@@ -42,6 +42,8 @@ _(loosely in this order...)_
 
 * [ ] replace core `grunt.file` internal module with `grunt-legacy-file`
 * [ ] remove any dependencies that are no longer needed from grunt.
+* [ ] enable travis
+* [ ] add travis badge
 
 ## Related projects
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "verb": "0.7.0"
   },
   "keywords": [
+    "grunt-legacy",
     "file",
     "fs",
     "grunt"

--- a/test/copy.js
+++ b/test/copy.js
@@ -14,13 +14,15 @@ var Tempfile = require('temporary/lib/file');
 var Tempdir = require('temporary/lib/dir');
 var tempdir = new Tempdir();
 var utils = require('./utils');
-var file = require('..');
+var File = require('..');
+var file;
 
 describe('.copy():', function () {
   var defaultEncoding;
   var tempfile;
 
   beforeEach(function (done) {
+    file = new File({grunt: grunt});
     defaultEncoding = file.defaultEncoding;
     file.defaultEncoding = 'utf8';
     done();

--- a/test/delete.js
+++ b/test/delete.js
@@ -14,7 +14,8 @@ var path = require('path');
 var grunt = require('grunt');
 var Tempdir = require('temporary/lib/dir');
 var tempdir = new Tempdir();
-var file = require('..');
+var File = require('..');
+var file;
 
 fs.symlinkSync(path.resolve('test/fixtures/octocat.png'), path.join(tempdir.path, 'octocat.png'), 'file');
 fs.symlinkSync(path.resolve('test/fixtures/expand'), path.join(tempdir.path, 'expand'), 'dir');
@@ -22,12 +23,14 @@ fs.symlinkSync(path.resolve('test/fixtures/expand'), path.join(tempdir.path, 'ex
 describe('file.delete():', function () {
   var original, cwd;
 
-  before(function(cb) {
+  before(function(done) {
+    file = new File({grunt: grunt});
     this.writeOption = grunt.option('write');
 
     // Testing that warnings were displayed.
     this.oldFailWarnFn = grunt.fail.warn;
     this.oldLogWarnFn = grunt.log.warn;
+
     this.resetWarnCount = function() {
       this.warnCount = 0;
     }.bind(this);
@@ -35,24 +38,20 @@ describe('file.delete():', function () {
     grunt.fail.warn = grunt.log.warn = function() {
       this.warnCount += 1;
     }.bind(this);
-    cb();
+
+    original = process.cwd();
+    cwd = path.resolve(tempdir.path, 'delete', 'folder');
+    done();
   });
 
-  after(function(cb) {
-    file.defaultEncoding = this.defaultEncoding;
+  after(function(done) {
+    // file.defaultEncoding = this.defaultEncoding;
     grunt.option('write', this.writeOption);
 
     grunt.fail.warn = this.oldFailWarnFn;
     grunt.log.warn = this.oldLogWarnFn;
-    cb();
-  });
-
-  before(function () {
-    original = process.cwd();
-    cwd = path.resolve(tempdir.path, 'delete', 'folder');
-  });
-  after(function () {
     file.setBase(original);
+    done();
   });
 
   describe('basic delete operations:', function () {

--- a/test/exists.js
+++ b/test/exists.js
@@ -9,15 +9,21 @@
 
 var assert = require('assert');
 var fs = require('fs');
+var grunt = require('grunt');
 var path = require('path');
 var Tempdir = require('temporary/lib/dir');
 var tempdir = new Tempdir();
-var file = require('..');
+var File = require('..');
+var file;
 
 fs.symlinkSync(path.resolve('test/fixtures/octocat.png'), path.join(tempdir.path, 'octocat.png'), 'file');
 fs.symlinkSync(path.resolve('test/fixtures/expand'), path.join(tempdir.path, 'expand'), 'dir');
 
 describe('file.exists():', function () {
+  beforeEach(function () {
+    file = new File({grunt: grunt});
+  });
+
   it('should return `true` when a file exists:', function () {
     assert.equal(file.exists('test/fixtures/octocat.png'), true);
   });

--- a/test/expand.js
+++ b/test/expand.js
@@ -10,9 +10,11 @@
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
+var grunt = require('grunt');
 var Tempdir = require('temporary/lib/dir');
 var tempdir = new Tempdir();
-var file = require('..');
+var File = require('..');
+var file;
 var cwd;
 
 fs.symlinkSync(path.resolve('test/fixtures/octocat.png'), path.join(tempdir.path, 'octocat.png'), 'file');
@@ -20,6 +22,7 @@ fs.symlinkSync(path.resolve('test/fixtures/expand'), path.join(tempdir.path, 'ex
 
 describe('file.expand():', function () {
   beforeEach(function (cb) {
+    file = new File({grunt: grunt});
     cwd = process.cwd();
     process.chdir('test/fixtures/expand');
     cb();

--- a/test/expandMapping.js
+++ b/test/expandMapping.js
@@ -10,9 +10,11 @@
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
+var grunt = require('grunt');
 var Tempdir = require('temporary/lib/dir');
 var tempdir = new Tempdir();
-var file = require('..');
+var File = require('..');
+var file;
 
 fs.symlinkSync(path.resolve('test/fixtures/octocat.png'), path.join(tempdir.path, 'octocat.png'), 'file');
 fs.symlinkSync(path.resolve('test/fixtures/expand'), path.join(tempdir.path, 'expand'), 'dir');
@@ -21,6 +23,7 @@ describe('file.expandMapping():', function () {
   var actual, expected;
 
   beforeEach(function (done) {
+    file = new File({grunt: grunt});
     this.cwd = process.cwd();
     process.chdir('test/fixtures');
     done();

--- a/test/isMatch.js
+++ b/test/isMatch.js
@@ -8,9 +8,15 @@
 'use strict';
 
 var assert = require('assert');
-var file = require('..');
+var grunt = require('grunt');
+var File = require('..');
+var file;
 
 describe('file.isMatch():', function () {
+  beforeEach(function () {
+    file = new File({grunt: grunt});
+  });
+
   it('basic matching:', function () {
     assert.equal(file.isMatch('*.js', 'foo.js'), true);
     assert.equal(file.isMatch('*.js', ['foo.js']), true);

--- a/test/match.js
+++ b/test/match.js
@@ -8,9 +8,15 @@
 'use strict';
 
 var assert = require('assert');
-var file = require('..');
+var grunt = require('grunt');
+var File = require('..');
+var file;
 
 describe('file.match():', function () {
+  beforeEach(function () {
+    file = new File({grunt: grunt});
+  });
+
   it('Should return empty set if a required argument is missing or an empty set.', function () {
     assert.deepEqual(file.match(null, null), []);
     assert.deepEqual(file.match({}, null, null), []);

--- a/test/mkdir.js
+++ b/test/mkdir.js
@@ -10,10 +10,13 @@
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
-var file = require('..');
+var grunt = require('grunt');
+var File = require('..');
+var file;
 
 describe('.mkdir():', function () {
   before(function () {
+    file = new File({grunt: grunt});
     file.mkdir(__dirname + '/temp');
   });
   after(function () {

--- a/test/path.js
+++ b/test/path.js
@@ -10,14 +10,20 @@
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
+var grunt = require('grunt');
 var Tempdir = require('temporary/lib/dir');
 var tempdir = new Tempdir();
-var file = require('..');
+var File = require('..');
+var file;
 
 fs.symlinkSync(path.resolve('test/fixtures/octocat.png'), path.join(tempdir.path, 'octocat.png'), 'file');
 fs.symlinkSync(path.resolve('test/fixtures/expand'), path.join(tempdir.path, 'expand'), 'dir');
 
 describe('path:', function () {
+  beforeEach(function () {
+    file = new File({grunt: grunt});
+  });
+
   describe('.isPathAbsolute():', function () {
     it('should work for directories with a leading slash:', function () {
       assert.equal(file.isPathAbsolute(path.resolve('/foo')), true);

--- a/test/read.js
+++ b/test/read.js
@@ -9,8 +9,10 @@
 
 var assert = require('assert');
 var fs = require('fs');
-var file = require('..');
+var grunt = require('grunt');
 var utils = require('./utils');
+var File = require('..');
+var file;
 
 describe('.read():', function () {
   var string = 'Ação é isso aí\n';
@@ -18,6 +20,7 @@ describe('.read():', function () {
   var defaultEncoding;
 
   beforeEach(function (done) {
+    file = new File({grunt: grunt});
     defaultEncoding = file.defaultEncoding;
     file.defaultEncoding = 'utf8';
     done();

--- a/test/recurse.js
+++ b/test/recurse.js
@@ -8,9 +8,15 @@
 'use strict';
 
 var assert = require('assert');
-var file = require('..');
+var grunt = require('grunt');
+var File = require('..');
+var file;
 
 describe('file.recurse():', function () {
+  beforeEach(function () {
+    file = new File({grunt: grunt});
+  });
+
   it('paths and arguments should match.', function () {
     var rootdir = 'test/fixtures/expand';
     var expected = {};

--- a/test/stat.js
+++ b/test/stat.js
@@ -10,15 +10,21 @@
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
+var grunt = require('grunt');
 var Tempdir = require('temporary/lib/dir');
 var tempdir = new Tempdir();
-var file = require('..');
+var File = require('..');
+var file;
 
 fs.symlinkSync(path.resolve('test/fixtures/octocat.png'), path.join(tempdir.path, 'octocat.png'), 'file');
 fs.symlinkSync(path.resolve('test/fixtures/expand'), path.join(tempdir.path, 'expand'), 'dir');
 
 
 describe('.stat():', function () {
+  beforeEach(function () {
+    file = new File({grunt: grunt});
+  });
+
   describe('.isLink() - false:', function () {
     it('should return false when files are not symlinks.', function () {
       assert.notEqual(file.isLink('test/fixtures/octocat.png'), true);

--- a/test/write.js
+++ b/test/write.js
@@ -14,13 +14,15 @@ var grunt = require('grunt');
 var Tempfile = require('temporary/lib/file');
 var Tempdir = require('temporary/lib/dir');
 var utils = require('./utils');
-var file = require('..');
+var File = require('..');
+var file;
 
 describe('.write():', function () {
   var string = 'Ação é isso aí\n';
   var defaultEncoding;
 
   beforeEach(function () {
+    file = new File({grunt: grunt});
     defaultEncoding = file.defaultEncoding;
     file.defaultEncoding = 'utf8';
   });


### PR DESCRIPTION
Currently this implementation falls back to a default `grunt` when Grunt is not passed on the options. By way of comparison, `grunt-legacy-log`, expects the implementor to pass an instance of grunt but does not throw an error if not passed. IMHO, an error should be thrown to make this explicit and to avoid adding additional logic to account for grunt not being passed.

